### PR TITLE
Add description to Room

### DIFF
--- a/api.go
+++ b/api.go
@@ -112,6 +112,7 @@ type Room struct {
 	TaskNum        int    `json:"task_num"`
 	IconPath       string `json:"icon_path"`
 	LastUpdateTime int64  `json:"last_update_time"`
+	Description    string `json:"description"`
 }
 
 // Rooms GET "/rooms"

--- a/client_test.go
+++ b/client_test.go
@@ -1,25 +1,25 @@
 package gochatwork
 
 import (
-        "testing"
-        "reflect"
+	"reflect"
+	"testing"
 )
 
 const ApiKey = ``
 
 func expect(t *testing.T, a interface{}, b interface{}) {
-        if a != b {
-                t.Errorf("Expected %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
-        }
+	if a != b {
+		t.Errorf("Expected %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	}
 }
 
 func refute(t *testing.T, a interface{}, b interface{}) {
-        if a == b {
-                t.Errorf("Did not expect %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
-        }
+	if a == b {
+		t.Errorf("Did not expect %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+	}
 }
 
 func TestNewClient(t *testing.T) {
-        c := NewClient(ApiKey)
-        refute(t, c, nil)
+	c := NewClient(ApiKey)
+	refute(t, c, nil)
 }


### PR DESCRIPTION
http://developer.chatwork.com/ja/endpoint_rooms.html#GET-rooms-room_id

# Example
```go
apiKey = "XXXXXXXXXXXXX"
client = chatwork.NewClient(apiKey)

rooms := client.Rooms()
fmt.Printf("%+v\n", rooms[0])
// => {RoomID:00000000 Name:雑談 Type:group Role:member Sticky:true UnreadNum:0 MentionNum:0 MytaskNum:0 MessageNum:12473 FileNum:511 TaskNum:1 IconPath:https://xxxxxxxx LastUpdateTime:1446885545 Description:}

room := client.Room(strconv.Itoa(rooms[0].RoomID))
fmt.Printf("%+v\n", room)
// => {RoomID:00000000 Name:雑談 Type:group Role:member Sticky:true UnreadNum:0 MentionNum:0 MytaskNum:0 MessageNum:12473 FileNum:511 TaskNum:1 IconPath:https://xxxxxxxx LastUpdateTime:1446885545 Description:XXXXXXXXXXXX}
```

If append a `Description`, this is no problem with both `Client.Rooms` and `Client.Room`
