### PR TITLE
Add RateLimit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ func main() {
     "assigned_by_account_id": "123",
     "status": "open"
   })
+  
+  chatwork.RateLimit()
 
   ...
 }

--- a/api.go
+++ b/api.go
@@ -318,3 +318,23 @@ func (c *Client) RoomFile(roomID, fileID string, params map[string]string) File 
 	json.Unmarshal(ret, &file)
 	return file
 }
+
+// RateLimit model
+type RateLimit struct {
+	Limit     int
+	Remaining int
+	ResetTime int64
+}
+
+// ResetDate time.Time representation of ResetTime
+func (r RateLimit) ResetDate() time.Time {
+	return time.Unix(r.ResetTime, 0)
+}
+
+func (c *Client) RateLimit() *RateLimit {
+	if c.latestRateLimit == nil {
+		// When API is not called even once, call API and get RateLimit in response header
+		c.Me()
+	}
+	return c.latestRateLimit
+}

--- a/examples/contacts.go
+++ b/examples/contacts.go
@@ -17,4 +17,5 @@ func init() {
 func main() {
 	c := chatwork.NewClient(apiKey)
 	fmt.Printf("%+v\n", c.Contacts())
+	fmt.Printf("%+v\n", c.RateLimit())
 }

--- a/examples/me.go
+++ b/examples/me.go
@@ -17,4 +17,5 @@ func init() {
 func main() {
 	c := chatwork.NewClient(apiKey)
 	fmt.Printf("%+v\n", c.Me())
+	fmt.Printf("%+v\n", c.RateLimit())
 }

--- a/examples/my.go
+++ b/examples/my.go
@@ -18,4 +18,5 @@ func main() {
 	c := chatwork.NewClient(apiKey)
 	fmt.Printf("%+v\n", c.MyStatus())
 	fmt.Printf("%+v\n", c.MyTasks(map[string]string{}))
+	fmt.Printf("%+v\n", c.RateLimit())
 }

--- a/examples/rooms.go
+++ b/examples/rooms.go
@@ -49,4 +49,6 @@ func main() {
 	c.DeleteRoom(`room-id`, map[string]string{
 		"action_type": "delete",
 	})
+
+	fmt.Printf("%+v\n", c.RateLimit())
 }


### PR DESCRIPTION
Store a API ratelimit with each api calls, and return with `RateLimit()`

ref. http://developer.chatwork.com/ja/endpoints.html#apiLimit

# Example
```go
apiKey = "XXXXXXXXXXXXX"
client = chatwork.NewClient(apiKey)

// a few api calls

rateLimit := client.RateLimit()
// => &{Limit:100 Remaining:97 ResetTime:1451321505}

rateLimit.ResetDate()
// => 2015-12-29 01:51:45 +0900 JST
```
